### PR TITLE
integrate GitHub Deployments API for Vercel preview and production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,24 @@ jobs:
           DEPLOY_URL=$(vercel deploy --prebuilt --token=$VERCEL_TOKEN --yes | grep -o 'https://[a-zA-Z0-9.-]*\.vercel\.app' | tail -n1)
           echo "deploymentUrl=$DEPLOY_URL" >> $GITHUB_OUTPUT
 
+      - name: Report Preview Deployment to GitHub
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/deployments \
+            -f ref="${{ github.head_ref }}" \
+            -f environment="Preview" \
+            -f auto_merge=false \
+            -f required_contexts="[]" \
+            -f transient_environment=true \
+            -f production_environment=false > deployment.json
+          DEPLOYMENT_ID=$(jq '.id' deployment.json)
+          gh api repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses \
+            -f state=success \
+            -f environment_url="${{ steps.deploy.outputs.deploymentUrl }}" \
+            -f description="Preview deployment ready" \
+            -f log_url="${{ steps.deploy.outputs.deploymentUrl }}"
+
       - name: Comment Preview URL on PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -99,10 +117,30 @@ jobs:
           vercel build --prod --token=$VERCEL_TOKEN
 
       - name: Deploy to Vercel (Production)
+        id: deploy
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --yes
+          PROD_URL=$(vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --yes | grep -o 'https://[a-zA-Z0-9.-]*\.vercel\.app' | tail -n1)
+          echo "prodUrl=$PROD_URL" >> $GITHUB_OUTPUT
+
+      - name: Report Production Deployment to GitHub
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/deployments \
+            -f ref=main \
+            -f environment="Production" \
+            -f auto_merge=false \
+            -f required_contexts="[]" \
+            -f transient_environment=false \
+            -f production_environment=true > deployment.json
+          DEPLOYMENT_ID=$(jq '.id' deployment.json)
+          gh api repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses \
+            -f state=success \
+            -f environment_url="https://www.conveysoft.dev" \
+            -f description="Production deployment live" \
+            -f log_url="${{ steps.deploy.outputs.prodUrl }}"
 
   release:
     name: Create GitHub Release


### PR DESCRIPTION
- Adds GitHub deployment status updates to both preview (PR) and production deployments
- Uses gh CLI to create deployments and update statuses with environment/log URLs
- Ensures deployments appear in the GitHub "Deployments" tab